### PR TITLE
Adds support for Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,9 @@ jobs:
         exclude:
           - laravel: 11.*
             php: 8.1
+          - laravel: 11.*
+            php: 8.2
+            os: windows-latest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,21 +13,17 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 8.1, 8.2]
-        laravel: [8.*, 9.*, 10.*]
+        php: [8.1, 8.2]
+        laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: ^6.24
-          - laravel: 9.*
-            testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
         exclude:
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 8.*
-            php: 8.2
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .php_cs
 .php_cs.cache
 .phpunit.result.cache
+.phpunit.cache
 build
 composer.lock
 coverage

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.47|^9.0|^10.0",
+        "illuminate/contracts": "^8.47|^9.0|^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.3|^6.0",
-        "orchestra/testbench": "^6.24|^7.0|^8.0",
-        "phpunit/phpunit": "^9.5",
-        "vimeo/psalm": "^4.8"
+        "nunomaduro/collision": "^7.0|^8.1",
+        "orchestra/testbench": "^8.0|^9.0",
+        "phpunit/phpunit": "^10.5",
+        "vimeo/psalm": "^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/config/globalid.php
+++ b/config/globalid.php
@@ -11,5 +11,5 @@ return [
      | it as "Rich Text Laravel", the GIDs will be "gid://rich-text-laravel/Model/1".
      |
      */
-    'app_name' => env('APP_NAME', 'Laravel'),
+    'app_name' => env('GLOBALID_APP_NAME', env('APP_NAME', 'Laravel')),
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     executionOrder="random"
@@ -16,27 +12,23 @@
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="Tonysm Test Suite">
+        <testsuite name="Globalid Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
-        <junit outputFile="build/report.junit.xml"/>
+        <junit outputFile="build/report.junit.xml" />
     </logging>
     <php>
         <server name="APP_NAME" value="Laravel" />
     </php>
+    <source>
+    <include>
+        <directory suffix=".php">./src</directory>
+    </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
### Added

- Adds support for Laravel 11. The support for Laravel 8 and 9 will be removed later, but that's something for the next major version. I'm removing them from CI, though.
- Allow setting a globalid-specific app name via `GLOBALID_APP_NAME`

---

closes #8 