### PR TITLE
Encryption key rotation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+This file provides guidance to Coding Agents when working with code in this repository.
+
+## Overview
+
+A Laravel package that provides Global IDs — app-wide URIs that uniquely identify model instances (`gid://AppName/ModelClass/id`). Inspired by the Rails `globalid` gem. Supports both plain Global IDs and Signed Global IDs (with expiration and purpose-based verification).
+
+## Commands
+
+- **Run all tests:** `composer test` (uses `testbench package:test --parallel`)
+- **Run a single test:** `vendor/bin/phpunit tests/path/to/TestFile.php`
+- **Run a single test method:** `vendor/bin/phpunit --filter test_method_name`
+- **Lint/format:** `composer lint` (runs Laravel Pint)
+
+## Architecture
+
+**Namespace:** `Tonysm\GlobalId`
+
+### Core Classes
+
+- **`GlobalId`** — Represents a GID URI. Creates, parses, and locates models from GID strings or base64-encoded versions. Static `$app` holds the default app name.
+- **`SignedGlobalId`** (extends `GlobalId`) — Adds HMAC signing, expiration, and purpose-based verification. Uses `Verifier` with the app key via PBKDF2. Default expiry: 1 month.
+- **`URI\GID`** — Low-level value object that parses/builds the `gid://` URI scheme. Handles URL encoding of model names and IDs.
+- **`Locator`** — Service (scoped singleton) that resolves GIDs to model instances. Supports per-app custom locators and an `only` option to restrict which model classes can be located.
+- **`Locators\BaseLocator`** — Default locator using Eloquent's `find`/`findMany`.
+- **`Locators\LocatorContract`** — Interface for custom locators (`locate` and `locateMany`).
+- **`Verifier`** — Signs and verifies SGID payloads (HMAC-SHA256).
+- **`Models\HasGlobalIdentification`** — Trait added to Eloquent models providing `toGlobalId()`, `toGid()`, `toSignedGlobalId()`, `toSgid()`.
+
+### Testing
+
+Tests use Orchestra Testbench with an in-memory SQLite database. Test models live in `tests/Stubs/Models/`. The base `TestCase` creates `people` and `uuid_people` tables in `getEnvironmentSetUp`.
+
+## Compatibility
+
+Supports PHP 8.2+, Laravel 8.47 through 13.x. CI matrix tests across PHP 8.2–8.5, Laravel 10–13, on Ubuntu and Windows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
         <junit outputFile="build/report.junit.xml" />
     </logging>
     <php>
+        <server name="APP_KEY" value="base64:DZ6j00yIELHx7bzILDwqu/JTi/otQUiofbpTlbjsGOU=" />
         <server name="APP_NAME" value="Laravel" />
     </php>
     <source>

--- a/src/Exceptions/LocatorException.php
+++ b/src/Exceptions/LocatorException.php
@@ -12,4 +12,11 @@ class LocatorException extends RuntimeException
             'One or many of the models passed to the locate many could not be found.'
         );
     }
+
+    public static function unknownApp(string $app)
+    {
+        return new static(
+            "No locator registered for app \"{$app}\". Register one with Locator::use('{$app}', ...)."
+        );
+    }
 }

--- a/src/GlobalId.php
+++ b/src/GlobalId.php
@@ -31,9 +31,9 @@ class GlobalId
      * Sets the default app name to be used when creating new
      * GlobalIds without specific app names.
      */
-    public static function useAppName(string $app): void
+    public static function useAppName(string $app): string
     {
-        static::$app = GID::validateAppName($app);
+        return static::$app = GID::validateAppName($app);
     }
 
     /**
@@ -43,11 +43,7 @@ class GlobalId
      */
     public static function appName(): string
     {
-        if (! static::$app ?? false) {
-            static::useAppName(Str::slug(config('globalid.app_name')));
-        }
-
-        return static::$app;
+        return static::$app ??= static::useAppName(Str::slug(config('globalid.app_name')));
     }
 
     /**

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -5,6 +5,7 @@ namespace Tonysm\GlobalId;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Tonysm\GlobalId\Exceptions\GlobalIdException;
+use Tonysm\GlobalId\Exceptions\LocatorException;
 use Tonysm\GlobalId\Locators\BaseLocator;
 use Tonysm\GlobalId\Locators\LocatorContract;
 use Tonysm\GlobalId\URI\GID;
@@ -111,7 +112,17 @@ class Locator
      */
     private function locatorFor(GlobalId $globalId): LocatorContract
     {
-        return $this->locators[$this->normalizeApp($globalId->app())] ?? new BaseLocator;
+        $app = $this->normalizeApp($globalId->app());
+
+        if (isset($this->locators[$app])) {
+            return $this->locators[$app];
+        }
+
+        if ($app === $this->normalizeApp(GlobalId::appName())) {
+            return new BaseLocator;
+        }
+
+        throw LocatorException::unknownApp($globalId->app());
     }
 
     /**

--- a/src/SignedGlobalId.php
+++ b/src/SignedGlobalId.php
@@ -106,21 +106,34 @@ class SignedGlobalId extends GlobalId
      */
     private static function configuredVerifier()
     {
-        return new Verifier(function () {
-            $appKey = config('app.key');
+        return new Verifier(
+            salt: 'signed_global_ids',
+            keyResolver: fn () => static::deriveKey(config('app.key')),
+            previousKeysResolver: function () {
+                return array_map(
+                    fn (string $key) => static::deriveKey($key),
+                    array_filter(config('app.previous_keys', [])),
+                );
+            },
+        );
+    }
 
-            if (str_starts_with($appKey, 'base64:')) {
-                $appKey = base64_decode(substr($appKey, 7));
-            }
+    /**
+     * Derives a signing key from a Laravel app key using PBKDF2.
+     */
+    private static function deriveKey(string $appKey): string
+    {
+        if (str_starts_with($appKey, 'base64:')) {
+            $appKey = base64_decode(substr($appKey, 7));
+        }
 
-            return hash_pbkdf2(
-                'sha256',
-                $appKey,
-                'signed_global_ids',
-                static::ITERATIONS,
-                static::KEY_SIZE,
-            );
-        }, salt: 'signed_global_ids');
+        return hash_pbkdf2(
+            'sha256',
+            $appKey,
+            'signed_global_ids',
+            static::ITERATIONS,
+            static::KEY_SIZE,
+        );
     }
 
     /**

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -39,12 +39,12 @@ class Verifier
 
         [$encoded, $signature] = $split;
 
-        if ($this->hashWithKey($encoded, $this->key()) === $signature) {
+        if ($this->signatureMatches($encoded, $signature, $this->key())) {
             return json_decode(base64_decode($encoded), true);
         }
 
         foreach ($this->previousKeys() as $previousKey) {
-            if ($this->hashWithKey($encoded, $previousKey) === $signature) {
+            if ($this->signatureMatches($encoded, $signature, $previousKey)) {
                 return json_decode(base64_decode($encoded), true);
             }
         }
@@ -64,6 +64,15 @@ class Verifier
         $signature = $this->hash($encoded);
 
         return "{$encoded}--{$signature}";
+    }
+
+    /**
+     * Checks if the given signature matches the expected HMAC for the encoded data.
+     * Uses hash_equals for constant-time comparison to prevent timing attacks.
+     */
+    private function signatureMatches(string $encoded, string $signature, string $key): bool
+    {
+        return hash_equals($this->hashWithKey($encoded, $key), $signature);
     }
 
     /**

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -13,9 +13,14 @@ class Verifier
     private string $cachedKey;
 
     /**
+     * The cached previous keys. Resolved lazily only when the current key fails verification.
+     */
+    private ?array $cachedPreviousKeys = null;
+
+    /**
      * Creates an instance of the Verifier class.
      */
-    public function __construct(private Closure $keyResolver, private string $salt) {}
+    public function __construct(private Closure $keyResolver, private string $salt, private ?Closure $previousKeysResolver = null) {}
 
     /**
      * Verifies the Signed Global Id string matches with the signature.
@@ -34,13 +39,17 @@ class Verifier
 
         [$encoded, $signature] = $split;
 
-        $rehased = $this->hash($encoded);
-
-        if ($rehased !== $signature) {
-            throw new InvalidSignatureException;
+        if ($this->hashWithKey($encoded, $this->key()) === $signature) {
+            return json_decode(base64_decode($encoded), true);
         }
 
-        return json_decode(base64_decode($encoded), true);
+        foreach ($this->previousKeys() as $previousKey) {
+            if ($this->hashWithKey($encoded, $previousKey) === $signature) {
+                return json_decode(base64_decode($encoded), true);
+            }
+        }
+
+        throw new InvalidSignatureException;
     }
 
     /**
@@ -58,11 +67,19 @@ class Verifier
     }
 
     /**
-     * Generates the signature of an encoded string.
+     * Generates the signature of an encoded string using a specific key.
+     */
+    private function hashWithKey(string $encoded, string $key): string
+    {
+        return hash_hmac('sha256', $encoded, $key.$this->salt);
+    }
+
+    /**
+     * Generates the signature of an encoded string using the current key.
      */
     private function hash(string $encoded): string
     {
-        return hash_hmac('sha256', $encoded, $this->key().$this->salt);
+        return $this->hashWithKey($encoded, $this->key());
     }
 
     /**
@@ -71,5 +88,19 @@ class Verifier
     private function key(): string
     {
         return $this->cachedKey ??= call_user_func($this->keyResolver);
+    }
+
+    /**
+     * Gets the previous keys used for verification fallback.
+     *
+     * @return string[]
+     */
+    private function previousKeys(): array
+    {
+        if ($this->previousKeysResolver === null) {
+            return [];
+        }
+
+        return $this->cachedPreviousKeys ??= call_user_func($this->previousKeysResolver);
     }
 }

--- a/tests/GlobalLocatorTest.php
+++ b/tests/GlobalLocatorTest.php
@@ -334,7 +334,31 @@ class GlobalLocatorTest extends TestCase
     }
 
     #[Test]
-    public function use_locator()
+    public function locating_gid_with_unknown_app_throws_exception()
+    {
+        $this->expectException(LocatorException::class);
+
+        Locator::locate('gid://unknown-app/Person/1');
+    }
+
+    #[Test]
+    public function locating_many_gids_with_unknown_app_throws_exception()
+    {
+        $this->expectException(LocatorException::class);
+
+        Locator::locateMany(['gid://unknown-app/Person/1']);
+    }
+
+    #[Test]
+    public function locating_gid_with_current_app_works_without_explicit_locator()
+    {
+        $found = Locator::locate($this->gid);
+
+        $this->assertTrue($this->model->is($found));
+    }
+
+    #[Test]
+    public function locating_gid_with_registered_app_works()
     {
         Locator::use('foo', new class implements LocatorContract
         {

--- a/tests/SignedGlobalIdCustomParamsTest.php
+++ b/tests/SignedGlobalIdCustomParamsTest.php
@@ -25,7 +25,8 @@ class SignedGlobalIdCustomParamsTest extends TestCase
     #[Test]
     public function parse_custom_params()
     {
-        $sgid = SignedGlobalId::parse('eyJzZ2lkIjoiZ2lkOlwvXC9sYXJhdmVsXC9Ub255c20lNUNHbG9iYWxJZCU1Q1Rlc3RzJTVDU3R1YnMlNUNNb2RlbHMlNUNQZXJzb25cLzE/aGVsbG89d29ybGQiLCJwdXJwb3NlIjoiZGVmYXVsdCIsImV4cGlyZXNfYXQiOiIyMDIxLTA5LTIxVDE4OjUxOjIwWiJ9--131a0c93a84f48a315c1bab0e310440bb9c2c24fe3bf285bf2fa92303d18bd49');
+        $sgid = SignedGlobalId::parse('eyJzZ2lkIjoiZ2lkOlwvXC9sYXJhdmVsXC9Ub255c20lNUNHbG9iYWxJZCU1Q1Rlc3RzJTVDU3R1YnMlNUNNb2RlbHMlNUNQZXJzb25cLzE/aGVsbG89d29ybGQiLCJwdXJwb3NlIjoiZGVmYXVsdCIsImV4cGlyZXNfYXQiOiIyMDIxLTA5LTIxVDE4OjUxOjIwWiJ9--692ce83526b900f93c5a50119919c28893a437327f7cb914a31eee6d9a025e0a');
+
         $this->assertEquals('world', $sgid->getParam('hello'));
     }
 }

--- a/tests/SignedGlobalIdKeyRotationTest.php
+++ b/tests/SignedGlobalIdKeyRotationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tonysm\GlobalId\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tonysm\GlobalId\SignedGlobalId;
+use Tonysm\GlobalId\Tests\Stubs\Models\Person;
+
+class SignedGlobalIdKeyRotationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->travelTo(now()->parse('2021-09-21T18:07:45Z'));
+    }
+
+    #[Test]
+    public function parses_sgid_signed_with_previous_key()
+    {
+        $model = Person::create(['name' => 'rotation test']);
+
+        // Sign with the current key.
+        $sgid = SignedGlobalId::create($model);
+        $sgidString = $sgid->toString();
+
+        // Rotate the key: move the current key to previous_keys and set a new one.
+        $oldKey = config('app.key');
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        config()->set('app.previous_keys', [$oldKey]);
+
+        // The SGID signed with the old key should still parse successfully.
+        $parsed = SignedGlobalId::parse($sgidString);
+
+        $this->assertNotNull($parsed);
+        $this->assertEquals($model->id, $parsed->modelId());
+    }
+
+    #[Test]
+    public function returns_null_when_key_is_completely_unknown()
+    {
+        $model = Person::create(['name' => 'unknown key test']);
+
+        // Sign with the current key.
+        $sgid = SignedGlobalId::create($model);
+        $sgidString = $sgid->toString();
+
+        // Rotate to a new key without preserving the old one.
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        config()->set('app.previous_keys', []);
+
+        $parsed = SignedGlobalId::parse($sgidString);
+
+        $this->assertNull($parsed);
+    }
+
+    #[Test]
+    public function new_sgids_are_signed_with_current_key()
+    {
+        $model = Person::create(['name' => 'new key test']);
+
+        // Rotate the key.
+        $oldKey = config('app.key');
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        config()->set('app.previous_keys', [$oldKey]);
+
+        // Create a new SGID — should be signed with the new key.
+        $sgid = SignedGlobalId::create($model);
+        $sgidString = $sgid->toString();
+
+        // Remove previous keys — should still verify with current key only.
+        config()->set('app.previous_keys', []);
+
+        $parsed = SignedGlobalId::parse($sgidString);
+
+        $this->assertNotNull($parsed);
+        $this->assertEquals($model->id, $parsed->modelId());
+    }
+
+    #[Test]
+    public function handles_multiple_previous_keys()
+    {
+        $model = Person::create(['name' => 'multi rotation test']);
+
+        // Sign with the original key.
+        $sgid = SignedGlobalId::create($model);
+        $sgidString = $sgid->toString();
+
+        // Simulate two key rotations.
+        $originalKey = config('app.key');
+        $secondKey = 'base64:'.base64_encode(random_bytes(32));
+        $thirdKey = 'base64:'.base64_encode(random_bytes(32));
+
+        config()->set('app.key', $thirdKey);
+        config()->set('app.previous_keys', [$secondKey, $originalKey]);
+
+        $parsed = SignedGlobalId::parse($sgidString);
+
+        $this->assertNotNull($parsed);
+        $this->assertEquals($model->id, $parsed->modelId());
+    }
+}

--- a/tests/SignedGlobalIdPurposeTest.php
+++ b/tests/SignedGlobalIdPurposeTest.php
@@ -59,8 +59,8 @@ class SignedGlobalIdPurposeTest extends TestCase
     {
         $sgid = $this->loginSgid->toString();
 
-        $this->assertNull(SignedGlobalID::parse($sgid));
-        $this->assertNull(SignedGlobalID::parse($sgid, ['for' => 'like_button']));
+        $this->assertNull(SignedGlobalId::parse($sgid));
+        $this->assertNull(SignedGlobalId::parse($sgid, ['for' => 'like_button']));
     }
 
     #[Test]

--- a/tests/SignedGlobalIdPurposeTest.php
+++ b/tests/SignedGlobalIdPurposeTest.php
@@ -26,7 +26,7 @@ class SignedGlobalIdPurposeTest extends TestCase
     #[Test]
     public function sign_with_purpose_when_for_is_provided()
     {
-        $this->assertEquals('eyJzZ2lkIjoiZ2lkOlwvXC9sYXJhdmVsXC9Ub255c20lNUNHbG9iYWxJZCU1Q1Rlc3RzJTVDU3R1YnMlNUNNb2RlbHMlNUNQZXJzb25cLzEiLCJwdXJwb3NlIjoibG9naW4iLCJleHBpcmVzX2F0IjoiMjAyMS0xMC0yMVQxODowNzo0NVoifQ==--2608dcd66dd87acc6f20b44a399ab07672ea2a0be804ab6313ba8bb8c2a4bf0c', $this->loginSgid->toString());
+        $this->assertEquals('eyJzZ2lkIjoiZ2lkOlwvXC9sYXJhdmVsXC9Ub255c20lNUNHbG9iYWxJZCU1Q1Rlc3RzJTVDU3R1YnMlNUNNb2RlbHMlNUNQZXJzb25cLzEiLCJwdXJwb3NlIjoibG9naW4iLCJleHBpcmVzX2F0IjoiMjAyMS0xMC0yMVQxODowNzo0NVoifQ==--abbe97b9ea7d9402b1dae20a2a0d7dc47f66fd534eb14ee8c2981302677aafad', $this->loginSgid->toString());
     }
 
     #[Test]

--- a/tests/SignedGlobalIdTest.php
+++ b/tests/SignedGlobalIdTest.php
@@ -26,7 +26,7 @@ class SignedGlobalIdTest extends TestCase
     #[Test]
     public function to_string()
     {
-        $this->assertEquals('eyJzZ2lkIjoiZ2lkOlwvXC9sYXJhdmVsXC9Ub255c20lNUNHbG9iYWxJZCU1Q1Rlc3RzJTVDU3R1YnMlNUNNb2RlbHMlNUNQZXJzb25cLzEiLCJwdXJwb3NlIjoiZGVmYXVsdCIsImV4cGlyZXNfYXQiOiIyMDIxLTEwLTIxVDE4OjA3OjQ1WiJ9--03906479811fcd37fc53deff414f525cd7cd94d844b0cb6d6e547e5a2d912740', $this->personSgid->toString());
+        $this->assertEquals('eyJzZ2lkIjoiZ2lkOlwvXC9sYXJhdmVsXC9Ub255c20lNUNHbG9iYWxJZCU1Q1Rlc3RzJTVDU3R1YnMlNUNNb2RlbHMlNUNQZXJzb25cLzEiLCJwdXJwb3NlIjoiZGVmYXVsdCIsImV4cGlyZXNfYXQiOiIyMDIxLTEwLTIxVDE4OjA3OjQ1WiJ9--e3c5048a34f3f57d7efd86b8db8a24f44489841cf69289b00938aea2379a7f48', $this->personSgid->toString());
     }
 
     #[Test]

--- a/tests/VerifierKeyRotationTest.php
+++ b/tests/VerifierKeyRotationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tonysm\GlobalId\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tonysm\GlobalId\Exceptions\InvalidSignatureException;
+use Tonysm\GlobalId\Verifier;
+
+class VerifierKeyRotationTest extends TestCase
+{
+    #[Test]
+    public function verifies_with_current_key()
+    {
+        $verifier = new Verifier(
+            fn () => 'current-key',
+            salt: 'salty',
+            previousKeysResolver: fn () => ['old-key'],
+        );
+
+        $sgid = $verifier->generate(['gid' => 'gid://laravel/Person/1']);
+
+        $this->assertEquals(
+            ['gid' => 'gid://laravel/Person/1'],
+            $verifier->verify($sgid),
+        );
+    }
+
+    #[Test]
+    public function verifies_with_previous_key_after_rotation()
+    {
+        $oldVerifier = new Verifier(fn () => 'old-key', salt: 'salty');
+        $sgid = $oldVerifier->generate(['gid' => 'gid://laravel/Person/1']);
+
+        $newVerifier = new Verifier(
+            fn () => 'new-key',
+            salt: 'salty',
+            previousKeysResolver: fn () => ['old-key'],
+        );
+
+        $this->assertEquals(
+            ['gid' => 'gid://laravel/Person/1'],
+            $newVerifier->verify($sgid),
+        );
+    }
+
+    #[Test]
+    public function verifies_with_second_previous_key()
+    {
+        $originalVerifier = new Verifier(fn () => 'original-key', salt: 'salty');
+        $sgid = $originalVerifier->generate(['gid' => 'gid://laravel/Person/1']);
+
+        $currentVerifier = new Verifier(
+            fn () => 'newest-key',
+            salt: 'salty',
+            previousKeysResolver: fn () => ['old-key', 'original-key'],
+        );
+
+        $this->assertEquals(
+            ['gid' => 'gid://laravel/Person/1'],
+            $currentVerifier->verify($sgid),
+        );
+    }
+
+    #[Test]
+    public function fails_verification_when_key_is_not_in_current_or_previous()
+    {
+        $unknownVerifier = new Verifier(fn () => 'unknown-key', salt: 'salty');
+        $sgid = $unknownVerifier->generate(['gid' => 'gid://laravel/Person/1']);
+
+        $verifier = new Verifier(
+            fn () => 'current-key',
+            salt: 'salty',
+            previousKeysResolver: fn () => ['old-key'],
+        );
+
+        $this->expectException(InvalidSignatureException::class);
+        $verifier->verify($sgid);
+    }
+
+    #[Test]
+    public function always_signs_with_current_key()
+    {
+        $currentVerifier = new Verifier(fn () => 'current-key', salt: 'salty');
+        $rotatedVerifier = new Verifier(
+            fn () => 'current-key',
+            salt: 'salty',
+            previousKeysResolver: fn () => ['old-key'],
+        );
+
+        $sgid1 = $currentVerifier->generate(['gid' => 'gid://laravel/Person/1']);
+        $sgid2 = $rotatedVerifier->generate(['gid' => 'gid://laravel/Person/1']);
+
+        $this->assertEquals($sgid1, $sgid2);
+    }
+
+    #[Test]
+    public function previous_keys_resolver_is_not_called_when_current_key_works()
+    {
+        $called = false;
+
+        $verifier = new Verifier(
+            fn () => 'current-key',
+            salt: 'salty',
+            previousKeysResolver: function () use (&$called) {
+                $called = true;
+
+                return ['old-key'];
+            },
+        );
+
+        $sgid = $verifier->generate(['gid' => 'gid://laravel/Person/1']);
+        $verifier->verify($sgid);
+
+        $this->assertFalse($called);
+    }
+}


### PR DESCRIPTION
### Changed

- Adds AGENTS.md
- Adds previous keys verifiers so we can support Laravel's key rotation more easily
- Only returns registered locators or if the GID uses the main app name, but don't return a fallback locator
- Check hashes using hash_equals instead of ===